### PR TITLE
해당 프로젝트용 ddl 추가 및 ignore 추가

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,7 +2,7 @@
 SPRING_PROFILES_ACTIVE=local
 
 # Database
-DB_URL=jdbc:mariadb://localhost:3306/account_book?useUnicode=true&characterEncoding=UTF-8&restrictedAuth=mysql_native_password
+DB_URL=jdbc:mariadb://localhost:3306/account_book?useUnicode=true&characterEncoding=UTF-8
 DB_USERNAME=root
 DB_PASSWORD={비밀번호입력}
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -77,3 +77,8 @@ cd backend
 - 현재 자동화 테스트는 스프링 컨텍스트 로드 테스트 중심입니다.
 - 위 6장 항목을 기준으로 서비스 단위/통합/보안 테스트를 순차 확장합니다.
 
+
+## 8. DB Bootstrap (after git pull)
+```bash
+mysql -u root -p < backend/sql/account_book_ddl.sql
+```

--- a/backend/sql/account_book_ddl.sql
+++ b/backend/sql/account_book_ddl.sql
@@ -1,0 +1,78 @@
+-- =========================================================
+-- 4th-study: MariaDB bootstrap DDL
+-- Purpose: allow teammates to run DB initialization after git pull
+-- Usage: mysql -u root -p < backend/sql/account_book_ddl.sql
+-- =========================================================
+
+CREATE DATABASE IF NOT EXISTS account_book
+  CHARACTER SET utf8mb4
+  COLLATE utf8mb4_unicode_ci;
+
+USE account_book;
+
+CREATE TABLE IF NOT EXISTS users (
+  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+  email VARCHAR(100) NOT NULL UNIQUE,
+  password VARCHAR(255) NOT NULL,
+  nickname VARCHAR(50) NOT NULL,
+  role VARCHAR(20) NOT NULL,
+  created_at DATETIME(6) NOT NULL,
+  updated_at DATETIME(6) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS accounts (
+  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+  user_id BIGINT NOT NULL,
+  name VARCHAR(100) NOT NULL,
+  balance BIGINT NOT NULL,
+  created_at DATETIME(6) NOT NULL,
+  updated_at DATETIME(6) NOT NULL,
+  CONSTRAINT fk_accounts_user
+    FOREIGN KEY (user_id) REFERENCES users(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS categories (
+  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+  user_id BIGINT NOT NULL,
+  name VARCHAR(50) NOT NULL,
+  type VARCHAR(20) NOT NULL,
+  created_at DATETIME(6) NOT NULL,
+  CONSTRAINT fk_categories_user
+    FOREIGN KEY (user_id) REFERENCES users(id),
+  CONSTRAINT uq_categories_user_name_type
+    UNIQUE (user_id, name, type)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS transactions (
+  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+  user_id BIGINT NOT NULL,
+  category_id BIGINT NOT NULL,
+  type VARCHAR(20) NOT NULL,
+  amount BIGINT NOT NULL,
+  description VARCHAR(255) NULL,
+  transaction_date DATE NOT NULL,
+  created_at DATETIME(6) NOT NULL,
+  updated_at DATETIME(6) NOT NULL,
+  CONSTRAINT fk_transactions_user
+    FOREIGN KEY (user_id) REFERENCES users(id),
+  CONSTRAINT fk_transactions_category
+    FOREIGN KEY (category_id) REFERENCES categories(id),
+  CONSTRAINT chk_transactions_amount
+    CHECK (amount >= 1)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS refresh_tokens (
+  user_email VARCHAR(100) PRIMARY KEY,
+  token VARCHAR(512) NOT NULL,
+  expiry_date DATETIME(6) NOT NULL,
+  CONSTRAINT fk_refresh_tokens_user_email
+    FOREIGN KEY (user_email) REFERENCES users(email)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Indexes (run on clean DB once)
+CREATE INDEX idx_accounts_user_id ON accounts(user_id);
+CREATE INDEX idx_categories_user_id ON categories(user_id);
+CREATE INDEX idx_transactions_user_id ON transactions(user_id);
+CREATE INDEX idx_transactions_category_id ON transactions(category_id);
+CREATE INDEX idx_transactions_date ON transactions(transaction_date);
+CREATE INDEX idx_transactions_user_date ON transactions(user_id, transaction_date);

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -6,6 +6,8 @@ dist/
 dist-ssr/
 coverage/
 *.tsbuildinfo
+.vite/
+.vite-temp/
 
 # Logs
 logs/


### PR DESCRIPTION
1. 초기 세팅을 위한 ddl 추가
 a. ddl 추가
  - backend/sql/account_book_ddl.sql
  - 포함 내용: CREATE DATABASE account_book, USE account_book, 테이블/제약조건/인덱스 생성
  
 b. env.example 수정 
  - backend/.env.example:5
  - restrictedAuth=mysql_native_password 제거해서 현재 로컬 설정과 일치시킴
  - 
 c. README.md 파일 수정
  - backend/README.md 하단에 DB bootstrap 명령 추가
  
2. vite 파일 gitignore 추가