### PR TITLE
거래 내역 검색 필터 기능 향상

### DIFF
--- a/backend/src/main/java/com/mycompany/_thstudy/transaction/query/controller/TransactionQueryController.java
+++ b/backend/src/main/java/com/mycompany/_thstudy/transaction/query/controller/TransactionQueryController.java
@@ -1,6 +1,7 @@
 package com.mycompany._thstudy.transaction.query.controller;
 
 import com.mycompany._thstudy.common.dto.ApiResponse;
+import com.mycompany._thstudy.transaction.query.dto.request.TransactionSearchRequest;
 import com.mycompany._thstudy.transaction.query.dto.response.DailySummaryResponse;
 import com.mycompany._thstudy.transaction.query.dto.response.MonthlySummaryResponse;
 import com.mycompany._thstudy.transaction.query.dto.response.TransactionListResponse;
@@ -29,9 +30,23 @@ public class TransactionQueryController {
   public ResponseEntity<ApiResponse<List<TransactionListResponse>>> getTransactions(
       @AuthenticationPrincipal UserDetails userDetails,
       @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
-      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
-    // TODO: transactionQueryService.getTransactions(userDetails.getUsername(), startDate, endDate) → 200
-    List<TransactionListResponse> response = transactionQueryService.getTransactions(userDetails.getUsername(),startDate,endDate);
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+      @RequestParam(required = false) String type,
+      @RequestParam(required = false) Long categoryId,
+      @RequestParam(required = false) String keyword,
+      @RequestParam(required = false) Long minAmount,
+      @RequestParam(required = false) Long maxAmount) {
+
+    TransactionSearchRequest req = new TransactionSearchRequest();
+    req.setStartDate(startDate);
+    req.setEndDate(endDate);
+    req.setType(type);
+    req.setCategoryId(categoryId);
+    req.setKeyword(keyword);
+    req.setMinAmount(minAmount);
+    req.setMaxAmount(maxAmount);
+
+    List<TransactionListResponse> response = transactionQueryService.getTransactions(userDetails.getUsername(), req);
     return ResponseEntity.ok(ApiResponse.success(response));
   }
 

--- a/backend/src/main/java/com/mycompany/_thstudy/transaction/query/dto/request/TransactionSearchRequest.java
+++ b/backend/src/main/java/com/mycompany/_thstudy/transaction/query/dto/request/TransactionSearchRequest.java
@@ -11,4 +11,9 @@ public class TransactionSearchRequest {
 
     private LocalDate startDate;
     private LocalDate endDate;
+    private String type;        // INCOME / EXPENSE (null 이면 전체)
+    private Long categoryId;    // null 이면 전체
+    private String keyword;     // description LIKE 검색
+    private Long minAmount;     // null 이면 하한 없음
+    private Long maxAmount;     // null 이면 상한 없음
 }

--- a/backend/src/main/java/com/mycompany/_thstudy/transaction/query/mapper/TransactionMapper.java
+++ b/backend/src/main/java/com/mycompany/_thstudy/transaction/query/mapper/TransactionMapper.java
@@ -1,5 +1,6 @@
 package com.mycompany._thstudy.transaction.query.mapper;
 
+import com.mycompany._thstudy.transaction.query.dto.request.TransactionSearchRequest;
 import com.mycompany._thstudy.transaction.query.dto.response.CategoryRawSummary;
 import com.mycompany._thstudy.transaction.query.dto.response.DailySummaryResponse;
 import com.mycompany._thstudy.transaction.query.dto.response.MonthlySummaryResponse;
@@ -7,16 +8,14 @@ import com.mycompany._thstudy.transaction.query.dto.response.TransactionListResp
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
-import java.time.LocalDate;
 import java.util.List;
 
 @Mapper
 public interface TransactionMapper {
 
-  List<TransactionListResponse> findByUserEmailAndDateRange(
+  List<TransactionListResponse> findByFilter(
           @Param("userEmail") String userEmail,
-          @Param("startDate") LocalDate startDate,
-          @Param("endDate") LocalDate endDate
+          @Param("req") TransactionSearchRequest req
   );
 
   List<CategoryRawSummary> findMonthlySummary(

--- a/backend/src/main/java/com/mycompany/_thstudy/transaction/query/service/TransactionQueryService.java
+++ b/backend/src/main/java/com/mycompany/_thstudy/transaction/query/service/TransactionQueryService.java
@@ -1,5 +1,6 @@
 package com.mycompany._thstudy.transaction.query.service;
 
+import com.mycompany._thstudy.transaction.query.dto.request.TransactionSearchRequest;
 import com.mycompany._thstudy.transaction.query.dto.response.CategoryRawSummary;
 import com.mycompany._thstudy.transaction.query.dto.response.DailySummaryResponse;
 import com.mycompany._thstudy.transaction.query.dto.response.MonthlySummaryResponse;
@@ -19,18 +20,14 @@ public class TransactionQueryService {
 
   private final TransactionMapper transactionMapper;
 
-  public List<TransactionListResponse> getTransactions(String userEmail, LocalDate startDate, LocalDate endDate) {
-    // TODO: 구현
-    // 1. startDate null → 당월 1일
-    if(startDate == null){
-      startDate = LocalDate.now().withDayOfMonth(1);
+  public List<TransactionListResponse> getTransactions(String userEmail, TransactionSearchRequest req) {
+    if (req.getStartDate() == null) {
+      req.setStartDate(LocalDate.now().withDayOfMonth(1));
     }
-    // 2. endDate null → 오늘
-    if(endDate == null){
-      endDate = LocalDate.now();
+    if (req.getEndDate() == null) {
+      req.setEndDate(LocalDate.now());
     }
-    // 3. transactionMapper.findByUserEmailAndDateRange(userEmail, startDate, endDate) 호출
-    return transactionMapper.findByUserEmailAndDateRange(userEmail,startDate,endDate);
+    return transactionMapper.findByFilter(userEmail, req);
   }
 
   public MonthlySummaryResponse getMonthlySummary(String userEmail, int year, int month) {

--- a/backend/src/main/resources/mapper/TransactionMapper.xml
+++ b/backend/src/main/resources/mapper/TransactionMapper.xml
@@ -3,9 +3,9 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.mycompany._thstudy.transaction.query.mapper.TransactionMapper">
 
-    <select id="findByUserEmailAndDateRange"
+    <select id="findByFilter"
             resultType="com.mycompany._thstudy.transaction.query.dto.response.TransactionListResponse">
-        /* TransactionMapper.findByUserEmailAndDateRange */
+        /* TransactionMapper.findByFilter */
         SELECT
             t.id,
             t.type,
@@ -17,8 +17,30 @@
         FROM transactions t
         JOIN categories c ON t.category_id = c.id
         JOIN users u ON t.user_id = u.id
-        WHERE u.email = #{userEmail}
-          AND t.transaction_date BETWEEN #{startDate} AND #{endDate}
+        <where>
+            u.email = #{userEmail}
+            <if test="req.startDate != null">
+                AND t.transaction_date >= #{req.startDate}
+            </if>
+            <if test="req.endDate != null">
+                AND t.transaction_date &lt;= #{req.endDate}
+            </if>
+            <if test="req.type != null and req.type != ''">
+                AND t.type = #{req.type}
+            </if>
+            <if test="req.categoryId != null">
+                AND t.category_id = #{req.categoryId}
+            </if>
+            <if test="req.keyword != null and req.keyword != ''">
+                AND t.description LIKE CONCAT('%', #{req.keyword}, '%')
+            </if>
+            <if test="req.minAmount != null">
+                AND t.amount >= #{req.minAmount}
+            </if>
+            <if test="req.maxAmount != null">
+                AND t.amount &lt;= #{req.maxAmount}
+            </if>
+        </where>
         ORDER BY t.transaction_date DESC, t.id DESC
     </select>
 


### PR DESCRIPTION
## 관련 이슈
#5 

## 변경 사항

### Backend
- `TransactionSearchRequest`에 필터 필드 추가 (`type`, `categoryId`, `keyword`, `minAmount`, `maxAmount`)
- `TransactionMapper`에 MyBatis 동적 쿼리(`findByFilter`) 적용 — null 필드는 WHERE 절에서 자동 제외
- `TransactionQueryController` 쿼리 파라미터 확장 및 `TransactionQueryService` 시그니처 변경

### Frontend
- 거래 내역 필터 UI 전면 개편
- 유형 필터 (전체 / 수입 / 지출)
- 카테고리 필터 (유형 선택 시 해당 유형의 카테고리만 표시)
- 메모 키워드 검색 (Enter 키 조회 지원)
- 금액 범위 필터 (최소 / 최대)
- 초기화 버튼
<img width="1209" height="421" alt="image" src="https://github.com/user-attachments/assets/96f57b20-d3f7-4348-ab6b-658b2c8acf24" />


 